### PR TITLE
Export dns module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfdkim"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfdkim"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Sven Sauleau <sven@cloudflare.com>"]
 edition = "2021"
 description = "DKIM (RFC6376) implementation"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate quick_error;
 
 mod bytes;
 pub mod canonicalization;
-mod dns;
+pub mod dns;
 mod errors;
 mod hash;
 mod header;


### PR DESCRIPTION
The dns module is needed when we want to supply our own resolver.