### PR TITLE
don't apply SMTP transparency decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2022-07-20
+
+### Changed
+
+- This library no longer performs the decoding of the SMTP transparency encoding before generating a signature.
+
+## [0.1.5] - 2022-06-28
+
+### Added
+
+- Exposed method in order to be able to provide an existing resolver.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfdkim"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfdkim"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Sven Sauleau <sven@cloudflare.com>"]
 edition = "2021"
 description = "DKIM (RFC6376) implementation"


### PR DESCRIPTION
The usual use case is having the data transparency-decoded when trying to sign/verify, so stop decoding it in module.