### PR TITLE
remove lifetime from the Signer struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfdkim"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "base64 0.21.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfdkim"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Sven Sauleau <sven@cloudflare.com>"]
 edition = "2021"
 description = "DKIM (RFC6376) implementation"

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ let private_key =
     rsa::RsaPrivateKey::read_pkcs1_pem_file(Path::new("./test/keys/2022.private"))?;
 
 let signer = SignerBuilder::new()
-    .with_signed_headers(&["From", "Subject"])?
+    .with_signed_headers(["From", "Subject"])?
     .with_private_key(private_key)
     .with_selector("2020")
-    .with_logger(&logger)
     .with_signing_domain("example.com")
     .build()?;
 let signature = signer.sign(&email)?;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -104,7 +104,7 @@ fn select_headers<'a>(
 }
 
 pub(crate) fn compute_headers_hash<'a, 'b>(
-    logger: &slog::Logger,
+    logger: Option<&slog::Logger>,
     canonicalization_type: canonicalization::Type,
     headers: &'b str,
     hash_algo: HashAlgo,
@@ -139,7 +139,9 @@ pub(crate) fn compute_headers_hash<'a, 'b>(
 
         input.extend_from_slice(&canonicalized_value);
     }
-    debug!(logger, "headers to hash: {:?}", input);
+    if let Some(logger) = logger {
+        debug!(logger, "headers to hash: {:?}", input);
+    }
 
     let hash = match hash_algo {
         HashAlgo::RsaSha1 => hash_sha1(&input),
@@ -323,7 +325,7 @@ Hello Alice
         let logger = slog::Logger::root(slog::Discard, slog::o!());
         assert_eq!(
             compute_headers_hash(
-                &logger,
+                Some(&logger),
                 canonicalization_type.clone(),
                 &headers,
                 hash_algo,
@@ -339,7 +341,7 @@ Hello Alice
         let hash_algo = HashAlgo::RsaSha256;
         assert_eq!(
             compute_headers_hash(
-                &logger,
+                Some(&logger),
                 canonicalization_type,
                 &headers,
                 hash_algo,
@@ -373,7 +375,7 @@ Hello Alice
         let logger = slog::Logger::root(slog::Discard, slog::o!());
         assert_eq!(
             compute_headers_hash(
-                &logger,
+                Some(&logger),
                 canonicalization_type.clone(),
                 &headers,
                 hash_algo,
@@ -389,7 +391,7 @@ Hello Alice
         let hash_algo = HashAlgo::RsaSha256;
         assert_eq!(
             compute_headers_hash(
-                &logger,
+                Some(&logger),
                 canonicalization_type,
                 &headers,
                 hash_algo,

--- a/src/header.rs
+++ b/src/header.rs
@@ -67,8 +67,7 @@ impl DKIMHeaderBuilder {
         self
     }
 
-    pub(crate) fn set_signed_headers(self, headers: &[&str]) -> Self {
-        let headers: Vec<String> = headers.iter().map(|h| h.to_lowercase()).collect();
+    pub(crate) fn set_signed_headers(self, headers: &Vec<String>) -> Self {
         let value = headers.join(":");
         self.add_tag("h", &value)
     }
@@ -106,11 +105,15 @@ mod tests {
         assert_eq!(header.raw_bytes, "v=1; a=something;".to_owned());
     }
 
+    fn signed_header_list(headers: &[&str]) -> Vec<String> {
+        headers.into_iter().map(|h| h.to_lowercase()).collect()
+    }
+
     #[test]
     fn test_dkim_header_builder_signed_headers() {
         let header = DKIMHeaderBuilder::new()
             .add_tag("v", "2")
-            .set_signed_headers(&["header1", "header2", "header3"])
+            .set_signed_headers(&signed_header_list(&["header1", "header2", "header3"]))
             .build()
             .unwrap();
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ async fn verify_email_header<'a>(
         email,
     )?;
     let computed_headers_hash = hash::compute_headers_hash(
-        logger,
+        Some(logger),
         header_canonicalization_type.clone(),
         &dkim_header.get_required_tag("h"),
         hash_algo.clone(),

--- a/src/roundtrip_test.rs
+++ b/src/roundtrip_test.rs
@@ -31,15 +31,13 @@ mod tests {
 
         let private_key =
             rsa::RsaPrivateKey::read_pkcs1_pem_file(Path::new("./test/keys/2022.private")).unwrap();
-        let logger = test_logger();
         let time = chrono::Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 1).unwrap();
 
         let signer = SignerBuilder::new()
-            .with_signed_headers(&["From", "Subject"])
+            .with_signed_headers(["From", "Subject"])
             .unwrap()
             .with_private_key(DkimPrivateKey::Rsa(private_key))
             .with_selector("2022")
-            .with_logger(&logger)
             .with_signing_domain(domain)
             .with_time(time)
             .build()


### PR DESCRIPTION
Not sure if you'll go for this, but I'm hoping to avoid maintaining a fork!

It is rather difficult to reuse the `Signer` in a dynamic application with the lifetime present in the struct.

This commit removes the lifetime to make it easier to cache and reuse.

The logger has also been removed from the API for the signer. It was used only in one place to log a single debug line, and it is a bit of an imposition on the embedding application to require the use of the `slog` crate just for that, and its removal helps with the goal of removing lifetimes from the struct as well.

Some builder methods have been made a little more ergonomic by accepting values that are convertible to String rather than requiring str references.

Since this commit changes the API signature, it also bumps the version from 0.2 to 0.3.