### PR TITLE
handle split DNS records

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,4 +1,4 @@
-///! Various utility functions to operate on bytes
+//! Various utility functions to operate on bytes
 
 pub(crate) fn get_all_after<'a>(bytes: &'a [u8], end: &[u8]) -> &'a [u8] {
     if let Some(mut end_index) = find(bytes, end) {


### PR DESCRIPTION
When DNS records exceed the max size, they can be split. When we receive these records we need to join them before parsing.